### PR TITLE
don't fail if package has no BugReports (e.g. assertthat); fix call to as.POSIXct.numeric in get_github_info()

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -12,7 +12,7 @@ get_github_info <- function(package) {
 
 github_repo <- function(package) {
   desc <- desc::desc(package = package)
-  url_fields <- c(desc$get_urls(), desc$get_field("BugReports"))
+  url_fields <- c(desc$get_urls(), desc$get_field("BugReports", default = NULL))
   if (length(url_fields) == 0) {
     return(NA_character_)
   }

--- a/R/github.R
+++ b/R/github.R
@@ -2,7 +2,7 @@ get_github_info <- function(package) {
   repo <- github_repo(package)
 
   if (is.na(repo)) {
-    return(tibble::tibble(package, open_issues = NA_real_, last_updated = as.POSIXct(NA_real_), stars = NA_real_, forks = NA_real_))
+    return(tibble::tibble(package, open_issues = NA_real_, last_updated = as.POSIXct(NA_real_, origin = "1970-01-01"), stars = NA_real_, forks = NA_real_))
   }
 
   res <- gh::gh("GET /repos/:repo", repo = repo)


### PR DESCRIPTION
Two small fixes to stop `itdepends::dep_weight("assertthat")` throwing an error.