### PR TITLE
Do not fail if not github development repo is found.

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -25,7 +25,8 @@ github_repo <- function(package) {
     "repo", "subdir")]
   parts <- unique(stats::na.omit(parts))
   if (nrow(parts) != 1) {
-    stop("Could not determine development repository", call. = FALSE)
+    warning("Could not determine development repository", call. = FALSE)
+    return(NA)
   }
   ref <- paste0(c(parts$username, parts$repo, if (nzchar(parts$subdir)) parts$subdir),
     collapse = "/")

--- a/R/weight.R
+++ b/R/weight.R
@@ -196,7 +196,7 @@ filter_deps <- function(deps, pkgs) {
 
 src_size <- function(pkgs) {
   cache <- pkgcache::cranlike_metadata_cache$new(platforms = "source", bioc = TRUE)
-  cache$list(pkgs)$filesize
+  unique(cache$list(pkgs)$filesize)
 }
 
 bin_size <- function(pkgs, platform = "macos") {


### PR DESCRIPTION
Hi @jimhester,

Thank you for this package.

We had an Issue on `tableone` where we were told that the installed size of the package was quite large.
https://github.com/kaz-yos/tableone/issues/58

To asses the size of our direct dependencies I tried to run `itdepends::dep_weight()` on each of the package imports.

```
find_deps("tableone", top_dep = NA, rec_dep = FALSE, include_pkgs = FALSE) %>% 
  dep_weight()
```

This failed because MASS, nlme, survival and zoo have no GitHub development repositories. 

As far as I could see you already planned for this case here:
https://github.com/r-lib/itdepends/blob/f8d012bff826c74de0b09f256ec08cde1ab28729/R/github.R#L4-L6

I only changed the stop into a warning in the `github_repo` function and now it's working.

The second commit fixes, that the src size is returned twice for MASS and nlme. This happens if the packages are installed twice with the same version.

I hope you find this changes useful.

Greetings,
Alex




